### PR TITLE
threads: Fix stencil examples

### DIFF
--- a/threads/stencil_funneled.c
+++ b/threads/stencil_funneled.c
@@ -163,11 +163,12 @@ int main(int argc, char **argv)
                 tmp = anew;
                 anew = aold;
                 aold = tmp;
+
+                /* optional - print image */
+                if (iter == niters - 1)
+                    printarr_par(iter, anew, n, px, py, rx, ry, bx, by, offx, offy, ind_f,
+                                 MPI_COMM_WORLD);
             }
-            /* optional - print image */
-            if (iter == niters - 1)
-                printarr_par(iter, anew, n, px, py, rx, ry, bx, by, offx, offy, ind_f,
-                             MPI_COMM_WORLD);
         }
     }
     t2 = MPI_Wtime();

--- a/threads/stencil_multiple.c
+++ b/threads/stencil_multiple.c
@@ -221,12 +221,12 @@ int main(int argc, char **argv)
                 tmp = anew;
                 anew = aold;
                 aold = tmp;
-            }
 
-            /* optional - print image */
-            if (iter == niters - 1)
-                printarr_par(iter, anew, n, px, py, rx, ry, bx, by, offx, offy, ind_f,
-                             MPI_COMM_WORLD);
+                /* optional - print image */
+                if (iter == niters - 1)
+                    printarr_par(iter, anew, n, px, py, rx, ry, bx, by, offx, offy, ind_f,
+                                 MPI_COMM_WORLD);
+            }
         }
     }
 

--- a/threads/stencil_multiple_ncomms.c
+++ b/threads/stencil_multiple_ncomms.c
@@ -235,12 +235,13 @@ int main(int argc, char **argv)
                 tmp = anew;
                 anew = aold;
                 aold = tmp;
-            }
 
-            /* optional - print image */
-            if (iter == niters - 1)
-                printarr_par(iter, anew, n, px, py, rx, ry, bx, by, offx, offy, ind_f,
-                             MPI_COMM_WORLD);
+                /* optional - print image */
+                if (iter == niters - 1)
+                    printarr_par(iter, anew, n, px, py, rx, ry, bx, by, offx, offy, ind_f,
+                                 MPI_COMM_WORLD);
+
+            }
         }
     }
 


### PR DESCRIPTION
printarr_par makes MPI calls, so it must be called in a master thread
region for correctness. Fixes #3.