### PR TITLE
Fixes to Makefiles

### DIFF
--- a/accelerators/Makefile.acc
+++ b/accelerators/Makefile.acc
@@ -4,8 +4,8 @@
 #
 
 CC=mpicc
-CFLAGS= -acc -g
-STENCIL_COMMON_SRC=../common/stencil/printarr_par.c
+CFLAGS= -acc -g -I../common
+STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS=$(CFLAGS) -I../common/stencil
 BSPMM_COMMON_SRC=../common/bspmm/bspmm_common.c
 BSPMM_CFLAGS=$(CFLAGS) -I../common/bspmm

--- a/accelerators/Makefile.omp
+++ b/accelerators/Makefile.omp
@@ -4,8 +4,8 @@
 #
 
 CC=mpicc
-CFLAGS= -fopenmp -g
-STENCIL_COMMON_SRC=../common/stencil/printarr_par.c
+CFLAGS= -fopenmp -g -I../common
+STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS=$(CFLAGS) -I../common/stencil
 BINS=stencil
 

--- a/mpi_io/Makefile
+++ b/mpi_io/Makefile
@@ -4,8 +4,8 @@
 #
 
 CC=mpicc
-STENCIL_COMMON_SRC=../common/stencil/printarr_par.c
-STENCIL_CFLAGS= -g -I../common/stencil
+STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/perf_stat.c
+STENCIL_CFLAGS= -g -I../common/stencil -I../common
 BINS=stencil_carttopo_chkpt_coll stencil_carttopo_chkpt_icoll stencil_carttopo_chkpt_indep stencil_carttopo_chkpt_serial
 
 all: $(BINS)

--- a/rma/Makefile
+++ b/rma/Makefile
@@ -4,8 +4,8 @@
 #
 
 CC=mpicc
-CFLAGS= -g -Wall
-STENCIL_COMMON_SRC=../common/stencil/printarr_par.c
+CFLAGS= -g -Wall -I../common
+STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS=$(CFLAGS) -I../common/stencil
 BSPMM_COMMON_SRC=../common/bspmm/bspmm_common.c
 BSPMM_CFLAGS=$(CFLAGS) -I../common/bspmm

--- a/shared_mem/Makefile
+++ b/shared_mem/Makefile
@@ -4,8 +4,8 @@
 #
 
 CC=mpicc
-CFLAGS= -g -Wall
-STENCIL_COMMON_SRC=../common/stencil/printarr_par.c
+CFLAGS= -g -Wall -I../common
+STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS= $(CFLAGS) -I../common/stencil
 BSPMM_COMMON_SRC=../common/bspmm/bspmm_common.c
 BSPMM_CFLAGS=$(CFLAGS) -I../common/bspmm

--- a/threads/Makefile
+++ b/threads/Makefile
@@ -4,8 +4,8 @@
 #
 
 CC=mpicc
-CFLAGS= -g -Wall -fopenmp
-STENCIL_COMMON_SRC=../common/stencil/printarr_par.c
+CFLAGS= -g -Wall -fopenmp -I../common
+STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS=$(CFLAGS) -I../common/stencil
 BSPMM_COMMON_SRC=../common/bspmm/bspmm_common.c
 BSPMM_CFLAGS=$(CFLAGS) -I../common/bspmm

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -4,8 +4,8 @@
 #
 
 CC=mpicc
-CFLAGS= -g -Wall
-STENCIL_COMMON_SRC=../common/stencil/printarr_par.c
+CFLAGS= -g -Wall -I../common
+STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS= $(CFLAGS) -I../common/stencil
 BINS=stencil_hotspot
 

--- a/topology/Makefile
+++ b/topology/Makefile
@@ -4,8 +4,8 @@
 #
 
 CC=mpicc
-CFLAGS= -g -Wall
-STENCIL_COMMON_SRC=../common/stencil/printarr_par.c
+CFLAGS= -g -Wall -I../common
+STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS= $(CFLAGS) -I../common/stencil
 BINS=stencil_carttopo stencil_carttopo_neighcolls
 


### PR DESCRIPTION
Include common header directory in CFLAGS. Add missing source file for stencil examples.