### PR TITLE
stencil: Guard update_grid declaration

### DIFF
--- a/common/stencil/stencil_par.h
+++ b/common/stencil/stencil_par.h
@@ -25,7 +25,9 @@ void refresh_heat_source(int bx, int nsources, int sources[][2], int energy, dou
 
 void alloc_bufs(int bx, int by, double **aold_ptr, double **anew_ptr);
 
+#ifndef __NVCC__
 void update_grid(int bx, int by, double *aold, double *anew, double *heat_ptr);
+#endif
 
 void free_bufs(double *aold, double *anew);
 


### PR DESCRIPTION
If compiling the CUDA stencil example, update_grid is defined as a __global__ function to execute on the GPU. If the declaration in stencil_par.h is not removed, nvcc will complain:

stencil_cuda.cu(63): error: a __host__ function("update_grid") redeclared with __global__