### PR TITLE
derived_datatype: Add noncontig sendrecv examples

### DIFF
--- a/derived_datatype/Makefile
+++ b/derived_datatype/Makefile
@@ -13,6 +13,12 @@ BINS=stencil stencil_alltoallw bspmm_vector bspmm_subarray
 
 all: $(BINS)
 
+sendrecv_nc1: sendrecv_nc1.c
+
+sendrecv_nc2: sendrecv_nc2.c
+
+sendrecv_nc3: sendrecv_nc3.c
+
 stencil: stencil.c $(STENCIL_COMMON_SRC)
 	$(CC) $(STENCIL_CFLAGS) $^ -o $@ -lm
 

--- a/derived_datatype/sendrecv_nc1.c
+++ b/derived_datatype/sendrecv_nc1.c
@@ -1,0 +1,43 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    int rank, data[5];
+
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (rank == 0) {
+        data[0] = 0;
+        data[1] = 10;
+        data[2] = 20;
+        data[3] = 30;
+        data[4] = 40;
+        MPI_Send(&data[0], 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
+        MPI_Send(&data[2], 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
+        MPI_Send(&data[4], 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
+    } else if (rank == 1) {
+        data[0] = -1;
+        data[1] = -1;
+        data[2] = -1;
+        data[3] = -1;
+        data[4] = -1;
+        printf("[%d] before receiving: %d,%d,%d,%d,%d\n", rank,
+               data[0], data[1], data[2], data[3], data[4]);
+        MPI_Recv(&data[0], 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        MPI_Recv(&data[2], 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        MPI_Recv(&data[4], 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        printf("[%d] after receiving: %d,%d,%d,%d,%d\n", rank,
+               data[0], data[1], data[2], data[3], data[4]);
+    }
+
+    MPI_Finalize();
+    return 0;
+}

--- a/derived_datatype/sendrecv_nc2.c
+++ b/derived_datatype/sendrecv_nc2.c
@@ -1,0 +1,47 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    int rank, data[5];
+
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (rank == 0) {
+        int sendbuf[3];
+        data[0] = 0;
+        data[1] = 10;
+        data[2] = 20;
+        data[3] = 30;
+        data[4] = 40;
+        sendbuf[0] = data[0];
+        sendbuf[1] = data[2];
+        sendbuf[2] = data[4];
+        MPI_Send(sendbuf, 3, MPI_INT, 1, 0, MPI_COMM_WORLD);
+    } else if (rank == 1) {
+        int recvbuf[3];
+        data[0] = -1;
+        data[1] = -1;
+        data[2] = -1;
+        data[3] = -1;
+        data[4] = -1;
+        printf("[%d] before receiving: %d,%d,%d,%d,%d\n", rank,
+               data[0], data[1], data[2], data[3], data[4]);
+        MPI_Recv(recvbuf, 3, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        data[0] = recvbuf[0];
+        data[2] = recvbuf[1];
+        data[4] = recvbuf[2];
+        printf("[%d] after receiving: %d,%d,%d,%d,%d\n", rank,
+               data[0], data[1], data[2], data[3], data[4]);
+    }
+
+    MPI_Finalize();
+    return 0;
+}

--- a/derived_datatype/sendrecv_nc3.c
+++ b/derived_datatype/sendrecv_nc3.c
@@ -1,0 +1,45 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    int rank, data[5];
+    MPI_Datatype dtype;
+
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    MPI_Type_vector(3, 1, 2, MPI_INT, &dtype);
+    MPI_Type_commit(&dtype);
+
+    if (rank == 0) {
+        data[0] = 0;
+        data[1] = 10;
+        data[2] = 20;
+        data[3] = 30;
+        data[4] = 40;
+        MPI_Send(data, 1, dtype, 1, 0, MPI_COMM_WORLD);
+    } else if (rank == 1) {
+        data[0] = -1;
+        data[1] = -1;
+        data[2] = -1;
+        data[3] = -1;
+        data[4] = -1;
+        printf("[%d] before receiving: %d,%d,%d,%d,%d\n", rank,
+               data[0], data[1], data[2], data[3], data[4]);
+        MPI_Recv(data, 1, dtype, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        printf("[%d] after receiving: %d,%d,%d,%d,%d\n", rank,
+               data[0], data[1], data[2], data[3], data[4]);
+    }
+
+    MPI_Type_free(&dtype);
+
+    MPI_Finalize();
+    return 0;
+}


### PR DESCRIPTION
A more basic introduction to the concept of noncontiguous send and recv. Attendees have not always understood the concept of noncontiguous data in memory, so spell it out more explicitly before diving into the stencil code.