### PR TITLE
make: Add support for Cray compiler wrappers

### DIFF
--- a/blocking_coll/Makefile
+++ b/blocking_coll/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
 CC=mpicc
+endif
 CFLAGS= -g -Wall -I../common
 STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/stencil/stencil_par.c ../common/perf_stat.c
 STENCIL_CFLAGS= $(CFLAGS) -I../common/stencil

--- a/blocking_p2p/Makefile
+++ b/blocking_p2p/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
 CC=mpicc
+endif
 CFLAGS= -g -Wall
 BSPMM_COMMON_SRC=../common/bspmm/bspmm_common.c
 BSPMM_CFLAGS=$(CFLAGS) -I../common/bspmm

--- a/debug/Makefile
+++ b/debug/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
 CC=mpicc
+endif
 CFLAGS= -O0 -g -Wall
 BINS=simple deadlock split
 

--- a/derived_datatype/Makefile
+++ b/derived_datatype/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
 CC=mpicc
+endif
 CFLAGS= -g -Wall -I../common
 STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/stencil/stencil_par.c ../common/perf_stat.c
 STENCIL_CFLAGS= $(CFLAGS) -I../common/stencil

--- a/mpi_io/Makefile
+++ b/mpi_io/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
 CC=mpicc
+endif
 STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS= -g -I../common/stencil -I../common
 BINS=stencil_carttopo_chkpt_coll stencil_carttopo_chkpt_icoll stencil_carttopo_chkpt_indep stencil_carttopo_chkpt_serial

--- a/nonblocking_coll/Makefile
+++ b/nonblocking_coll/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
 CC=mpicc
+endif
 CFLAGS= -g -Wall -I../common
 STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/stencil/stencil_par.c ../common/perf_stat.c
 STENCIL_CFLAGS=$(CFLAGS) -I../common/stencil

--- a/nonblocking_p2p/Makefile
+++ b/nonblocking_p2p/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
 CC=mpicc
+endif
 CFLAGS= -g -Wall -I../common
 STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/stencil/stencil_par.c ../common/perf_stat.c
 STENCIL_CFLAGS=$(CFLAGS) -I../common/stencil

--- a/rma/Makefile
+++ b/rma/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
 CC=mpicc
+endif
 CFLAGS= -g -Wall -I../common
 STENCIL_COMMON_SRC=../common/stencil/stencil_par.c ../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS=$(CFLAGS) -I../common/stencil

--- a/serial/Makefile
+++ b/serial/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
-CC=gcc
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
+CC=mpicc
+endif
 CFLAGS= -g -Wall -I../common
 BINS=stencil stencil_complete
 STENCIL_DEPS=../common/stencil/printarr.c ../common/perf_stat.c
@@ -11,7 +15,7 @@ STENCIL_DEPS=../common/stencil/printarr.c ../common/perf_stat.c
 all: $(BINS)
 
 stencil: stencil.c
-	mpicc stencil.c -o stencil
+	$(CC) stencil.c -o stencil
 
 stencil_complete: stencil_complete.c $(STENCIL_DEPS)
 	$(CC) $(CFLAGS) $^ -o $@ -lm

--- a/shared_mem/Makefile
+++ b/shared_mem/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
 CC=mpicc
+endif
 CFLAGS= -g -Wall -I../common
 STENCIL_COMMON_SRC=../common/stencil/stencil_par.c ../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS= $(CFLAGS) -I../common/stencil

--- a/threads/Makefile
+++ b/threads/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
 CC=mpicc
+endif
 CFLAGS= -g -Wall -fopenmp -I../common
 STENCIL_COMMON_SRC=../common/stencil/stencil_par.c ../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS=$(CFLAGS) -I../common/stencil

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
 CC=mpicc
+endif
 CFLAGS= -g -Wall -I../common
 STENCIL_COMMON_SRC=../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS= $(CFLAGS) -I../common/stencil

--- a/topology/Makefile
+++ b/topology/Makefile
@@ -3,7 +3,11 @@
 # See COPYRIGHT in top-level directory.
 #
 
+ifdef CRAY_CPU_TARGET
+CC=cc
+else
 CC=mpicc
+endif
 CFLAGS= -g -Wall -I../common
 STENCIL_COMMON_SRC=../common/stencil/stencil_par.c ../common/stencil/printarr_par.c ../common/perf_stat.c
 STENCIL_CFLAGS= $(CFLAGS) -I../common/stencil


### PR DESCRIPTION
For Cray systems, it is generally better to use the Cray compiler wrappers rather than mpicc and friends directly.